### PR TITLE
Improve battle evaluation scalability and add RL pipeline demo

### DIFF
--- a/Clash SL Server/Clash SL Server.csproj
+++ b/Clash SL Server/Clash SL Server.csproj
@@ -1340,6 +1340,8 @@
     <Compile Include="Packets\Messages\Client\PromoteAllianceMemberMessage.cs" />
     <Compile Include="Logic\Alliance.cs" />
     <Compile Include="Core\ObjectManager.cs" />
+    <Compile Include="Simulation\BatchAttackRunner.cs" />
+    <Compile Include="Simulation\RLBattlePipeline.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Tools\patch_generator.bat">

--- a/Clash SL Server/Logic/Battle.cs
+++ b/Clash SL Server/Logic/Battle.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using CSS.Core;
+using CSS.Files.Logic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UCS.Logic.JSONProperty;
@@ -23,6 +25,8 @@ namespace UCS.Logic
         ///     Gets or sets the battle tick.
         /// </summary>
         /// <value>The battle tick.</value>
+        internal bool EnableTickLogging { get; set; } = true;
+
         internal double BattleTick
         {
             get
@@ -35,18 +39,27 @@ namespace UCS.Logic
                 if (this.Preparation_Time >= 1 && this.Commands.Count < 1)
                 {
                     this.Preparation_Time -= (value - this.Last_Tick) / 63;
-                    Logger.Write("Preparation Time : " + this.Preparation_Time);
+                    if (this.EnableTickLogging)
+                    {
+                        Logger.Write("Preparation Time : " + this.Preparation_Time);
+                    }
                 }
                 else
                 {
                     this.Attack_Time -= (value - this.Last_Tick) / 63;
-                    Logger.Write("Attack Time      : " + this.Attack_Time);
+                    if (this.EnableTickLogging)
+                    {
+                        Logger.Write("Attack Time      : " + this.Attack_Time);
+                    }
                 }
                 this.Last_Tick = value;
                 this.End_Tick = (int) value;
 
             }
         }
+
+        JObject prototypeSource;
+        List<BuildingPrototype> buildingPrototypes;
 
         [JsonProperty("level")] internal JObject Base;
 
@@ -113,7 +126,288 @@ namespace UCS.Logic
             this.Replay_Info.Stats.Home_ID[1] = (int) this.Defender.LowID;
             this.Replay_Info.Stats.Original_Attacker_Score = this.Attacker.Trophies;
             this.Replay_Info.Stats.Original_Defender_Score = this.Defender.Trophies;
-            this.Replay_Info.Stats.Battle_Time = 180 - (int) this.Attack_Time + 1;
+        }
+
+        internal void EvaluateOutcome()
+        {
+            if (this.Commands == null)
+            {
+                return;
+            }
+
+            List<Battle_Command> orderedCommands = this.Commands
+                .OrderBy(c => c.Command_Base.Base.Tick)
+                .ToList();
+
+            if (orderedCommands.Count > 0)
+            {
+                this.BattleTick = orderedCommands[orderedCommands.Count - 1].Command_Base.Base.Tick;
+            }
+
+            List<BuildingSnapshot> buildings = this.CreateBuildingSnapshots();
+
+            if (buildings.Count > 0)
+            {
+                Dictionary<int, BuildingSnapshot> buildingsByInstance = buildings
+                    .Where(b => b.HasInstanceId)
+                    .ToDictionary(b => b.InstanceId, b => b);
+
+                Dictionary<int, List<BuildingSnapshot>> buildingBuckets = this.BuildBucketsByDataId(buildings);
+
+                foreach (Battle_Command command in orderedCommands)
+                {
+                    int data = command.Command_Base.Data;
+                    if (data <= 0)
+                    {
+                        continue;
+                    }
+
+                    int classId = GlobalID.GetClassID(data);
+
+                    if (classId == 500)
+                    {
+                        if (buildingsByInstance.TryGetValue(data, out BuildingSnapshot byInstance))
+                        {
+                            byInstance.Destroyed = true;
+                        }
+
+                        continue;
+                    }
+
+                    if (classId == 1 && buildingBuckets.TryGetValue(data, out List<BuildingSnapshot> bucket))
+                    {
+                        BuildingSnapshot snapshot = this.MatchBuilding(bucket, command.Command_Base.X, command.Command_Base.Y);
+                        if (snapshot != null)
+                        {
+                            snapshot.Destroyed = true;
+                        }
+                    }
+                }
+
+                int totalHitpoints = buildings.Sum(b => b.Hitpoints);
+                int destroyedHitpoints = buildings.Where(b => b.Destroyed).Sum(b => b.Hitpoints);
+
+                int destruction = 0;
+                if (totalHitpoints > 0)
+                {
+                    destruction = (int)Math.Round(destroyedHitpoints * 100.0 / totalHitpoints);
+                }
+
+                destruction = Math.Max(0, Math.Min(100, destruction));
+
+                bool townHallDestroyed = buildings.Any(b => b.IsTownHall && b.Destroyed);
+
+                int stars = 0;
+                if (destruction >= 50)
+                {
+                    stars++;
+                }
+
+                if (townHallDestroyed)
+                {
+                    stars++;
+                }
+
+                if (destruction >= 100)
+                {
+                    stars++;
+                }
+
+                this.Replay_Info.Stats.TownHall_Destroyed = townHallDestroyed;
+                this.Replay_Info.Stats.Destruction_Percentate = destruction;
+                this.Replay_Info.Stats.Attacker_Stars = Math.Max(0, Math.Min(3, stars));
+            }
+
+            this.Preparation_Time = Math.Max(0, this.Preparation_Time);
+            this.Attack_Time = Math.Max(0, this.Attack_Time);
+            this.Replay_Info.Stats.Battle_Ended = true;
+
+            int battleTime = (int)Math.Round(180 - this.Attack_Time);
+            if (battleTime < 0)
+            {
+                battleTime = 0;
+            }
+            else if (battleTime > 180)
+            {
+                battleTime = 180;
+            }
+
+            this.Replay_Info.Stats.Battle_Time = battleTime;
+        }
+
+        Dictionary<int, List<BuildingSnapshot>> BuildBucketsByDataId(IEnumerable<BuildingSnapshot> buildings)
+        {
+            var buckets = new Dictionary<int, List<BuildingSnapshot>>();
+
+            foreach (BuildingSnapshot building in buildings)
+            {
+                if (!buckets.TryGetValue(building.DataId, out List<BuildingSnapshot> list))
+                {
+                    list = new List<BuildingSnapshot>();
+                    buckets.Add(building.DataId, list);
+                }
+
+                list.Add(building);
+            }
+
+            return buckets;
+        }
+
+        BuildingSnapshot MatchBuilding(List<BuildingSnapshot> bucket, int x, int y)
+        {
+            BuildingSnapshot match = null;
+            int bestDistance = int.MaxValue;
+
+            foreach (BuildingSnapshot snapshot in bucket)
+            {
+                if (snapshot.Destroyed)
+                {
+                    continue;
+                }
+
+                int deltaX = snapshot.X - x;
+                int deltaY = snapshot.Y - y;
+                int distance = deltaX * deltaX + deltaY * deltaY;
+
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    match = snapshot;
+                }
+            }
+
+            if (match == null)
+            {
+                match = bucket.FirstOrDefault(b => !b.Destroyed);
+            }
+
+            return match;
+        }
+
+        List<BuildingSnapshot> CreateBuildingSnapshots()
+        {
+            if (this.Base == null)
+            {
+                this.buildingPrototypes = null;
+                this.prototypeSource = null;
+                return new List<BuildingSnapshot>();
+            }
+
+            if (!ReferenceEquals(this.Base, this.prototypeSource) || this.buildingPrototypes == null)
+            {
+                this.buildingPrototypes = this.BuildBuildingPrototypes();
+                this.prototypeSource = this.Base;
+            }
+
+            if (this.buildingPrototypes == null)
+            {
+                return new List<BuildingSnapshot>();
+            }
+
+            var snapshots = new List<BuildingSnapshot>(this.buildingPrototypes.Count);
+
+            foreach (BuildingPrototype prototype in this.buildingPrototypes)
+            {
+                snapshots.Add(prototype.CreateSnapshot());
+            }
+
+            return snapshots;
+        }
+
+        List<BuildingPrototype> BuildBuildingPrototypes()
+        {
+            var prototypes = new List<BuildingPrototype>();
+
+            JArray buildingsArray = this.Base["buildings"] as JArray;
+            if (buildingsArray == null)
+            {
+                return prototypes;
+            }
+
+            int generatedInstanceId = 500000000;
+
+            foreach (JToken token in buildingsArray)
+            {
+                JObject buildingObject = token as JObject;
+                if (buildingObject == null)
+                {
+                    continue;
+                }
+
+                int dataId = buildingObject.Value<int?>("data") ?? 0;
+                if (dataId == 0)
+                {
+                    continue;
+                }
+
+                BuildingData buildingData = CSVManager.DataTables.GetDataById(dataId) as BuildingData;
+                if (buildingData == null || buildingData.Hitpoints == null || buildingData.Hitpoints.Count == 0)
+                {
+                    continue;
+                }
+
+                int level = buildingObject.Value<int?>("lvl") ?? 0;
+                if (level >= buildingData.Hitpoints.Count)
+                {
+                    level = buildingData.Hitpoints.Count - 1;
+                }
+
+                int hitpoints = buildingData.Hitpoints[level];
+                if (hitpoints <= 0)
+                {
+                    continue;
+                }
+
+                int instanceId = buildingObject.Value<int?>("id") ?? generatedInstanceId++;
+
+                prototypes.Add(new BuildingPrototype
+                {
+                    InstanceId = instanceId,
+                    DataId = dataId,
+                    Hitpoints = hitpoints,
+                    X = buildingObject.Value<int?>("x") ?? 0,
+                    Y = buildingObject.Value<int?>("y") ?? 0,
+                    IsTownHall = buildingData.IsTownHall()
+                });
+            }
+
+            return prototypes;
+        }
+
+        class BuildingPrototype
+        {
+            internal int InstanceId;
+            internal int DataId;
+            internal int Hitpoints;
+            internal bool IsTownHall;
+            internal int X;
+            internal int Y;
+
+            internal BuildingSnapshot CreateSnapshot()
+            {
+                return new BuildingSnapshot
+                {
+                    InstanceId = this.InstanceId,
+                    DataId = this.DataId,
+                    Hitpoints = this.Hitpoints,
+                    IsTownHall = this.IsTownHall,
+                    X = this.X,
+                    Y = this.Y
+                };
+            }
+        }
+
+        class BuildingSnapshot
+        {
+            internal int InstanceId;
+            internal int DataId;
+            internal int Hitpoints;
+            internal bool IsTownHall;
+            internal bool Destroyed;
+            internal int X;
+            internal int Y;
+
+            internal bool HasInstanceId => InstanceId > 0;
         }
     }
 }

--- a/Clash SL Server/Simulation/BatchAttackRunner.cs
+++ b/Clash SL Server/Simulation/BatchAttackRunner.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using System.Linq;
+using UCS.Helpers;
+using UCS.Logic;
+using UCS.Logic.JSONProperty;
+using UCS.Logic.JSONProperty.Item;
+
+namespace UCS.Simulation
+{
+    internal class BatchAttackRunner
+    {
+        internal IEnumerable<BatchAttackResult> Run(
+            IEnumerable<BatchAttackWorkItem> workItems,
+            BatchAttackRunnerOptions options = null)
+        {
+            options ??= BatchAttackRunnerOptions.Default;
+
+            var results = new List<BatchAttackResult>();
+
+            if (workItems == null)
+            {
+                return results;
+            }
+
+            foreach (BatchAttackWorkItem workItem in workItems)
+            {
+                if (workItem == null || workItem.Battle == null)
+                {
+                    continue;
+                }
+
+                if (options.ResetBattleCommands)
+                {
+                    workItem.Battle.Commands.Clear();
+                }
+
+                if (options.ResetReplayInfo)
+                {
+                    workItem.Battle.Replay_Info = new Replay_Info();
+                }
+
+                foreach (Battle_Command command in workItem.Commands)
+                {
+                    workItem.Battle.Add_Command(command);
+                }
+
+                bool originalLoggingState = workItem.Battle.EnableTickLogging;
+                bool toggledLogging = false;
+
+                if (options.SuppressTickLogging && originalLoggingState)
+                {
+                    workItem.Battle.EnableTickLogging = false;
+                    toggledLogging = true;
+                }
+
+                try
+                {
+                    workItem.Battle.EvaluateOutcome();
+
+                    if (options.PopulateReplayInfo)
+                    {
+                        workItem.Battle.Set_Replay_Info();
+                    }
+
+                    string battleJson = options.SerializePayloads
+                        ? BattleSerializers.Serialize(workItem.Battle)
+                        : null;
+
+                    string replayJson = options.SerializePayloads
+                        ? BattleSerializers.Serialize(workItem.Battle.Replay_Info)
+                        : null;
+
+                    results.Add(new BatchAttackResult(workItem.Battle, battleJson, replayJson));
+                }
+                finally
+                {
+                    if (toggledLogging)
+                    {
+                        workItem.Battle.EnableTickLogging = originalLoggingState;
+                    }
+                }
+            }
+
+            return results;
+        }
+    }
+
+    internal class BatchAttackWorkItem
+    {
+        internal BatchAttackWorkItem(Battle battle, IEnumerable<Battle_Command> commands)
+        {
+            this.Battle = battle;
+            this.Commands = commands?.ToList() ?? new List<Battle_Command>();
+        }
+
+        internal Battle Battle { get; }
+
+        internal List<Battle_Command> Commands { get; }
+    }
+
+    internal class BatchAttackResult
+    {
+        internal BatchAttackResult(Battle battle, string battleJson, string replayJson)
+        {
+            this.Battle = battle;
+            this.BattleJson = battleJson;
+            this.ReplayJson = replayJson;
+        }
+
+        internal Battle Battle { get; }
+
+        internal string BattleJson { get; }
+
+        internal string ReplayJson { get; }
+
+        internal Replay_Info Replay => this.Battle.Replay_Info;
+    }
+
+    internal class BatchAttackRunnerOptions
+    {
+        internal static BatchAttackRunnerOptions Default => new BatchAttackRunnerOptions();
+
+        internal bool ResetBattleCommands { get; set; } = true;
+
+        internal bool ResetReplayInfo { get; set; } = true;
+
+        internal bool PopulateReplayInfo { get; set; } = true;
+
+        internal bool SerializePayloads { get; set; } = true;
+
+        internal bool SuppressTickLogging { get; set; } = true;
+    }
+}
+

--- a/Clash SL Server/Simulation/RLBattlePipeline.cs
+++ b/Clash SL Server/Simulation/RLBattlePipeline.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UCS.Logic;
+using UCS.Logic.JSONProperty.Item;
+
+namespace UCS.Simulation
+{
+    /// <summary>
+    ///     Thin orchestration layer that ties the batch simulation helper into a
+    ///     reinforcement-learning friendly loop. The pipeline generates commands for
+    ///     each episode via a policy, executes the battle server-side, and reports
+    ///     scalar rewards plus optional JSON payloads for logging.
+    /// </summary>
+    internal class RLBattlePipeline
+    {
+        readonly BatchAttackRunner runner;
+        readonly BatchAttackRunnerOptions runnerOptions;
+
+        internal RLBattlePipeline(BatchAttackRunner runner = null, BatchAttackRunnerOptions options = null)
+        {
+            this.runner = runner ?? new BatchAttackRunner();
+            this.runnerOptions = options ?? new BatchAttackRunnerOptions
+            {
+                SerializePayloads = false,
+                PopulateReplayInfo = true,
+                SuppressTickLogging = true,
+                ResetBattleCommands = true,
+                ResetReplayInfo = true
+            };
+        }
+
+        internal IEnumerable<RLEpisodeResult> RunEpisodes(IEnumerable<Battle> battles, IRLBattlePolicy policy)
+        {
+            if (battles == null)
+            {
+                return Enumerable.Empty<RLEpisodeResult>();
+            }
+
+            if (policy == null)
+            {
+                throw new ArgumentNullException(nameof(policy));
+            }
+
+            List<BatchAttackWorkItem> workItems = new List<BatchAttackWorkItem>();
+            List<RLEpisodeContext> contexts = new List<RLEpisodeContext>();
+
+            foreach (Battle battle in battles)
+            {
+                if (battle == null)
+                {
+                    continue;
+                }
+
+                IEnumerable<Battle_Command> commands = policy.GenerateCommands(battle);
+                var commandList = commands?.ToList() ?? new List<Battle_Command>();
+
+                workItems.Add(new BatchAttackWorkItem(battle, commandList));
+                contexts.Add(new RLEpisodeContext(battle, commandList));
+            }
+
+            List<BatchAttackResult> simulationResults = this.runner.Run(workItems, this.runnerOptions).ToList();
+
+            var episodeResults = new List<RLEpisodeResult>(simulationResults.Count);
+
+            for (int i = 0; i < simulationResults.Count; i++)
+            {
+                BatchAttackResult simulation = simulationResults[i];
+                RLEpisodeContext context = contexts[i];
+
+                double reward = policy.EvaluateReward(simulation);
+
+                episodeResults.Add(new RLEpisodeResult(
+                    context.Battle,
+                    context.Commands,
+                    simulation,
+                    reward));
+            }
+
+            return episodeResults;
+        }
+
+        internal static IEnumerable<RLEpisodeResult> Demo(IRLBattlePolicy policy, IEnumerable<(Battle battle, IEnumerable<Battle_Command> seed)> episodes)
+        {
+            if (episodes == null)
+            {
+                return Enumerable.Empty<RLEpisodeResult>();
+            }
+
+            var pipeline = new RLBattlePipeline();
+            var battles = new List<Battle>();
+
+            foreach ((Battle battle, IEnumerable<Battle_Command> seed) episode in episodes)
+            {
+                if (episode.battle == null)
+                {
+                    continue;
+                }
+
+                IEnumerable<Battle_Command> candidateCommands = episode.seed ?? Enumerable.Empty<Battle_Command>();
+                policy.WarmStart(episode.battle, candidateCommands);
+                battles.Add(episode.battle);
+            }
+
+            return pipeline.RunEpisodes(battles, policy);
+        }
+
+        class RLEpisodeContext
+        {
+            internal RLEpisodeContext(Battle battle, List<Battle_Command> commands)
+            {
+                this.Battle = battle;
+                this.Commands = commands;
+            }
+
+            internal Battle Battle { get; }
+
+            internal List<Battle_Command> Commands { get; }
+        }
+    }
+
+    internal interface IRLBattlePolicy
+    {
+        IEnumerable<Battle_Command> GenerateCommands(Battle battle);
+
+        double EvaluateReward(BatchAttackResult result);
+
+        void WarmStart(Battle battle, IEnumerable<Battle_Command> seedCommands);
+    }
+
+    /// <summary>
+    ///     Example reward function that targets high destruction and quick finishes.
+    ///     Stars are heavily weighted, destruction percent acts as tie-breaker, and
+    ///     faster clears earn a small bonus to encourage efficient policies.
+    /// </summary>
+    internal class WeightedRewardPolicy : IRLBattlePolicy
+    {
+        readonly double destructionWeight;
+        readonly double starWeight;
+        readonly double timeBonusWeight;
+        readonly IRLBattleCommandGenerator commandGenerator;
+
+        internal WeightedRewardPolicy(
+            IRLBattleCommandGenerator commandGenerator,
+            double starWeight = 10,
+            double destructionWeight = 1,
+            double timeBonusWeight = 0.05)
+        {
+            this.commandGenerator = commandGenerator;
+            this.starWeight = starWeight;
+            this.destructionWeight = destructionWeight;
+            this.timeBonusWeight = timeBonusWeight;
+        }
+
+        public IEnumerable<Battle_Command> GenerateCommands(Battle battle)
+        {
+            return this.commandGenerator?.Generate(battle) ?? Enumerable.Empty<Battle_Command>();
+        }
+
+        public double EvaluateReward(BatchAttackResult result)
+        {
+            if (result?.Replay?.Stats == null)
+            {
+                return 0;
+            }
+
+            double reward = result.Replay.Stats.Attacker_Stars * this.starWeight;
+            reward += result.Replay.Stats.Destruction_Percentate * this.destructionWeight;
+            reward += (180 - result.Replay.Stats.Battle_Time) * this.timeBonusWeight;
+
+            return reward;
+        }
+
+        public void WarmStart(Battle battle, IEnumerable<Battle_Command> seedCommands)
+        {
+            if (this.commandGenerator is ISeedableBattleCommandGenerator seedable && battle != null)
+            {
+                seedable.Seed(battle, seedCommands);
+            }
+        }
+    }
+
+    internal interface IRLBattleCommandGenerator
+    {
+        IEnumerable<Battle_Command> Generate(Battle battle);
+    }
+
+    internal interface ISeedableBattleCommandGenerator : IRLBattleCommandGenerator
+    {
+        void Seed(Battle battle, IEnumerable<Battle_Command> seedCommands);
+    }
+
+    internal class ReplayDrivenCommandGenerator : ISeedableBattleCommandGenerator
+    {
+        List<Battle_Command> replaySeed = new List<Battle_Command>();
+
+        public IEnumerable<Battle_Command> Generate(Battle battle)
+        {
+            return this.replaySeed;
+        }
+
+        public void Seed(Battle battle, IEnumerable<Battle_Command> seedCommands)
+        {
+            this.replaySeed = seedCommands?.ToList() ?? new List<Battle_Command>();
+        }
+    }
+
+    internal class RandomizedCommandGenerator : IRLBattleCommandGenerator
+    {
+        readonly Random random;
+        readonly List<Battle_Command> template;
+
+        internal RandomizedCommandGenerator(IEnumerable<Battle_Command> template, int? seed = null)
+        {
+            this.template = template?.ToList() ?? new List<Battle_Command>();
+            this.random = seed.HasValue ? new Random(seed.Value) : new Random();
+        }
+
+        public IEnumerable<Battle_Command> Generate(Battle battle)
+        {
+            if (battle == null || this.template.Count == 0)
+            {
+                return this.template;
+            }
+
+            return this.template
+                .OrderBy(_ => this.random.Next())
+                .Select((command, index) =>
+                {
+                    Battle_Command clone = CloneCommand(command);
+                    clone.Command_Base.Base.Tick += index * 63;
+                    return clone;
+                })
+                .ToList();
+        }
+
+        static Battle_Command CloneCommand(Battle_Command command)
+        {
+            if (command == null)
+            {
+                return new Battle_Command();
+            }
+
+            Command_Base baseCommand = command.Command_Base ?? new Command_Base();
+            Base baseData = baseCommand.Base ?? new Base();
+
+            return new Battle_Command
+            {
+                Command_Type = command.Command_Type,
+                Command_Base = new Command_Base
+                {
+                    Base = new Base
+                    {
+                        Tick = baseData.Tick
+                    },
+                    Data = baseCommand.Data,
+                    X = baseCommand.X,
+                    Y = baseCommand.Y
+                }
+            };
+        }
+    }
+
+    internal class RLEpisodeResult
+    {
+        internal RLEpisodeResult(
+            Battle battle,
+            IEnumerable<Battle_Command> commands,
+            BatchAttackResult simulation,
+            double reward)
+        {
+            this.Battle = battle;
+            this.Commands = commands?.ToList() ?? new List<Battle_Command>();
+            this.Simulation = simulation;
+            this.Reward = reward;
+        }
+
+        internal Battle Battle { get; }
+
+        internal List<Battle_Command> Commands { get; }
+
+        internal BatchAttackResult Simulation { get; }
+
+        internal double Reward { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- cache defender building prototypes and bucket matches by data id to speed up battle outcome evaluation while allowing tick logging to be suppressed
- expand the batch attack runner with configurable options for RL workloads and default logging suppression to keep large batches lightweight
- add an RL-oriented simulation pipeline with sample policies and command generators to demonstrate integrating the server evaluator into training loops

## Testing
- dotnet build 'Clash SL Server/Clash SL Server.csproj' *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df98f85bac8333a601b8d35c26457e