### PR TITLE
Add batch simulation mode for headless attack runs

### DIFF
--- a/Clash SL Server/Clash SL Server.csproj
+++ b/Clash SL Server/Clash SL Server.csproj
@@ -415,6 +415,8 @@
     <Compile Include="Packets\Messages\Server\PromoteAllianceMemberOkMessage.cs" />
     <Compile Include="Packets\Messages\Server\ReplayDataMessage.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="Simulation\BatchAttackOptions.cs" />
+    <Compile Include="Simulation\BatchAttackRunner.cs" />
     <Compile Include="CSSUI.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Clash SL Server/Program.cs
+++ b/Clash SL Server/Program.cs
@@ -22,8 +22,13 @@ namespace CSS
         public static Stopwatch _Stopwatch = new Stopwatch();
         public static string Version { get; set; }
 
-        internal static void Main()
+        internal static void Main(string[] args)
         {
+            if (CSS.Simulation.BatchAttackRunner.TryRun(args))
+            {
+                return;
+            }
+
             int GWL_EXSTYLE = -20;
             int WS_EX_LAYERED = 0x80000;
             uint LWA_ALPHA = 0x2;

--- a/Clash SL Server/Simulation/BatchAttackOptions.cs
+++ b/Clash SL Server/Simulation/BatchAttackOptions.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Globalization;
+using System.IO;
+
+namespace CSS.Simulation
+{
+    internal sealed class BatchAttackOptions
+    {
+        private BatchAttackOptions(
+            string baseLayoutPath,
+            string commandsPath,
+            string attackerHomePath,
+            string outputPath,
+            int attackCount,
+            double preparationTime,
+            double attackTime,
+            bool includeBattleState,
+            bool includeReplay,
+            bool silent,
+            long battleSeed)
+        {
+            BaseLayoutPath = baseLayoutPath;
+            CommandsPath = commandsPath;
+            AttackerHomePath = attackerHomePath;
+            OutputPath = outputPath;
+            AttackCount = attackCount;
+            PreparationTime = preparationTime;
+            AttackTime = attackTime;
+            IncludeBattleState = includeBattleState;
+            IncludeReplay = includeReplay;
+            Silent = silent;
+            BattleSeed = battleSeed;
+        }
+
+        internal string BaseLayoutPath { get; }
+
+        internal string CommandsPath { get; }
+
+        internal string AttackerHomePath { get; }
+
+        internal string OutputPath { get; }
+
+        internal int AttackCount { get; }
+
+        internal double PreparationTime { get; }
+
+        internal double AttackTime { get; }
+
+        internal bool IncludeBattleState { get; }
+
+        internal bool IncludeReplay { get; }
+
+        internal bool Silent { get; }
+
+        internal long BattleSeed { get; }
+
+        internal static bool TryParse(string[] args, out BatchAttackOptions options, out string error)
+        {
+            options = null;
+            error = null;
+
+            if (args == null || args.Length == 0)
+            {
+                return false;
+            }
+
+            bool requested = false;
+
+            string basePath = null;
+            string commandsPath = null;
+            string attackerHomePath = null;
+            string outputPath = null;
+            int attackCount = 1;
+            double preparationTime = 0;
+            double attackTime = 180;
+            bool includeBattleState = false;
+            bool includeReplay = true;
+            bool silent = false;
+            long battleSeed = DateTime.UtcNow.Ticks;
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string current = args[i];
+
+                switch (current)
+                {
+                    case "--simulate-batch":
+                        requested = true;
+                        break;
+
+                    case "--base":
+                        if (!TryReadValue(args, ref i, out basePath, out error))
+                        {
+                            return requested;
+                        }
+
+                        break;
+
+                    case "--commands":
+                        if (!TryReadValue(args, ref i, out commandsPath, out error))
+                        {
+                            return requested;
+                        }
+
+                        break;
+
+                    case "--attacker-home":
+                        if (!TryReadValue(args, ref i, out attackerHomePath, out error))
+                        {
+                            return requested;
+                        }
+
+                        break;
+
+                    case "--output":
+                        if (!TryReadValue(args, ref i, out outputPath, out error))
+                        {
+                            return requested;
+                        }
+
+                        break;
+
+                    case "--attacks":
+                    case "--repeat":
+                        {
+                            if (!TryReadValue(args, ref i, out string value, out error))
+                            {
+                                return requested;
+                            }
+
+                            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out attackCount) ||
+                                attackCount <= 0)
+                            {
+                                error = "--attacks must be a positive integer.";
+                                return requested;
+                            }
+
+                            break;
+                        }
+
+                    case "--prep":
+                    case "--preparation":
+                        {
+                            if (!TryReadValue(args, ref i, out string value, out error))
+                            {
+                                return requested;
+                            }
+
+                            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out preparationTime) ||
+                                preparationTime < 0)
+                            {
+                                error = "--prep must be zero or a positive number.";
+                                return requested;
+                            }
+
+                            break;
+                        }
+
+                    case "--attack-time":
+                    case "--attack":
+                        {
+                            if (!TryReadValue(args, ref i, out string value, out error))
+                            {
+                                return requested;
+                            }
+
+                            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out attackTime) ||
+                                attackTime <= 0)
+                            {
+                                error = "--attack must be a positive number.";
+                                return requested;
+                            }
+
+                            break;
+                        }
+
+                    case "--include-battle":
+                        includeBattleState = true;
+                        break;
+
+                    case "--no-replay":
+                        includeReplay = false;
+                        break;
+
+                    case "--silent":
+                    case "--quiet":
+                        silent = true;
+                        break;
+
+                    case "--seed":
+                        if (!TryReadValue(args, ref i, out string seedValue, out error))
+                        {
+                            return requested;
+                        }
+
+                        if (!long.TryParse(seedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out battleSeed))
+                        {
+                            error = "--seed must be a valid integer.";
+                            return requested;
+                        }
+
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            if (!requested)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(basePath))
+            {
+                error = "--base is required when using --simulate-batch.";
+                return true;
+            }
+
+            basePath = Path.GetFullPath(basePath);
+
+            if (!File.Exists(basePath))
+            {
+                error = $"Base layout file not found: {basePath}";
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(commandsPath))
+            {
+                commandsPath = Path.GetFullPath(commandsPath);
+
+                if (!File.Exists(commandsPath))
+                {
+                    error = $"Commands file not found: {commandsPath}";
+                    return true;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(attackerHomePath))
+            {
+                attackerHomePath = Path.GetFullPath(attackerHomePath);
+
+                if (!File.Exists(attackerHomePath))
+                {
+                    error = $"Attacker home file not found: {attackerHomePath}";
+                    return true;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(outputPath))
+            {
+                outputPath = Path.GetFullPath(outputPath);
+                string directory = Path.GetDirectoryName(outputPath);
+
+                if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+            }
+
+            options = new BatchAttackOptions(
+                basePath,
+                commandsPath,
+                attackerHomePath,
+                outputPath,
+                attackCount,
+                preparationTime,
+                attackTime,
+                includeBattleState,
+                includeReplay,
+                silent,
+                battleSeed);
+
+            return true;
+        }
+
+        private static bool TryReadValue(string[] args, ref int index, out string value, out string error)
+        {
+            if (index + 1 >= args.Length)
+            {
+                value = null;
+                error = $"Missing value for {args[index]}";
+                return false;
+            }
+
+            value = args[++index];
+            error = null;
+            return true;
+        }
+    }
+}

--- a/Clash SL Server/Simulation/BatchAttackRunner.cs
+++ b/Clash SL Server/Simulation/BatchAttackRunner.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CSS.Core;
+using CSS.Logic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UCS.Helpers;
+using UCS.Logic;
+using UCS.Logic.JSONProperty;
+using UCS.Logic.JSONProperty.Item;
+
+namespace CSS.Simulation
+{
+    internal static class BatchAttackRunner
+    {
+        internal static bool TryRun(string[] args)
+        {
+            bool parseResult = BatchAttackOptions.TryParse(args, out BatchAttackOptions options, out string error);
+
+            if (!parseResult)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(error))
+            {
+                Console.Error.WriteLine($"Simulation setup error: {error}");
+                Environment.ExitCode = 1;
+                return true;
+            }
+
+            Run(options);
+            return true;
+        }
+
+        private static void Run(BatchAttackOptions options)
+        {
+            EnsureGameFilesLoaded();
+
+            string baseLayoutJson = File.ReadAllText(options.BaseLayoutPath);
+            string attackerLayoutJson = string.IsNullOrWhiteSpace(options.AttackerHomePath)
+                ? null
+                : File.ReadAllText(options.AttackerHomePath);
+
+            List<List<Battle_Command>> commandSets = LoadCommandSets(options.CommandsPath);
+
+            if (commandSets.Count == 0)
+            {
+                commandSets.Add(new List<Battle_Command>());
+            }
+
+            TextWriter outputWriter = null;
+
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(options.OutputPath))
+                {
+                    outputWriter = new StreamWriter(options.OutputPath, append: false);
+                }
+
+                for (int attackIndex = 0; attackIndex < options.AttackCount; attackIndex++)
+                {
+                    List<Battle_Command> commands = commandSets[attackIndex % commandSets.Count];
+
+                    Battle battle = CreateBattle(baseLayoutJson, attackerLayoutJson, options, attackIndex);
+
+                    foreach (Battle_Command command in commands)
+                    {
+                        battle.Add_Command(command);
+                    }
+
+                    battle.Set_Replay_Info();
+
+                    JObject result = BuildResult(battle, attackIndex, commands.Count, options.IncludeBattleState, options.IncludeReplay);
+
+                    string serialized = result.ToString(Formatting.None);
+
+                    if (!options.Silent)
+                    {
+                        Console.WriteLine(serialized);
+                    }
+
+                    outputWriter?.WriteLine(serialized);
+                }
+            }
+            finally
+            {
+                outputWriter?.Dispose();
+            }
+        }
+
+        private static Battle CreateBattle(string baseLayoutJson, string attackerLayoutJson, BatchAttackOptions options, int index)
+        {
+            Level defender = new Level();
+            defender.SetHome(baseLayoutJson);
+
+            Level attacker = new Level();
+
+            if (!string.IsNullOrWhiteSpace(attackerLayoutJson))
+            {
+                attacker.SetHome(attackerLayoutJson);
+            }
+
+            Battle battle = new Battle(options.BattleSeed + index, attacker, defender, false)
+            {
+                Preparation_Time = options.PreparationTime,
+                Attack_Time = options.AttackTime
+            };
+
+            return battle;
+        }
+
+        private static JObject BuildResult(Battle battle, int attackIndex, int commandCount, bool includeBattleState, bool includeReplay)
+        {
+            JObject result = new JObject
+            {
+                ["attackIndex"] = attackIndex,
+                ["commandCount"] = commandCount,
+                ["preparationTimeRemaining"] = battle.Preparation_Time,
+                ["attackTimeRemaining"] = battle.Attack_Time,
+                ["battleId"] = battle.Battle_ID
+            };
+
+            if (includeReplay)
+            {
+                string replayJson = BattleSerializers.Serialize(battle.Replay_Info);
+                result["replay"] = replayJson.Length > 0 ? JToken.Parse(replayJson) : new JObject();
+            }
+
+            if (includeBattleState)
+            {
+                string battleJson = BattleSerializers.Serialize(battle);
+                result["battle"] = battleJson.Length > 0 ? JToken.Parse(battleJson) : new JObject();
+            }
+
+            return result;
+        }
+
+        private static List<List<Battle_Command>> LoadCommandSets(string commandsPath)
+        {
+            var commandSets = new List<List<Battle_Command>>();
+
+            if (string.IsNullOrWhiteSpace(commandsPath))
+            {
+                return commandSets;
+            }
+
+            string fileContent = File.ReadAllText(commandsPath).Trim();
+
+            if (string.IsNullOrWhiteSpace(fileContent))
+            {
+                return commandSets;
+            }
+
+            if (fileContent.StartsWith("[", StringComparison.Ordinal))
+            {
+                // Single command set shared across all simulations.
+                JArray array = JArray.Parse(fileContent);
+                commandSets.Add(ConvertCommands(array));
+                return commandSets;
+            }
+
+            foreach (string line in File.ReadLines(commandsPath))
+            {
+                string trimmed = line.Trim();
+
+                if (string.IsNullOrWhiteSpace(trimmed))
+                {
+                    continue;
+                }
+
+                JArray array = JArray.Parse(trimmed);
+                commandSets.Add(ConvertCommands(array));
+            }
+
+            return commandSets;
+        }
+
+        private static List<Battle_Command> ConvertCommands(JArray array)
+        {
+            var commands = new List<Battle_Command>(array.Count);
+
+            foreach (JToken token in array)
+            {
+                Battle_Command command = token.ToObject<Battle_Command>();
+
+                if (command != null)
+                {
+                    commands.Add(command);
+                }
+            }
+
+            return commands;
+        }
+
+        private static void EnsureGameFilesLoaded()
+        {
+            if (CSVManager.DataTables == null)
+            {
+                _ = new CSVManager();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a headless BatchAttackRunner that repeatedly spins up battle instances from saved layouts and optional command files
- expose command-line parsing for simulation mode so the server can exit early and avoid the normal UI/network startup
- register the new simulation helpers with the project file

## Testing
- not run (Windows-only project)


------
https://chatgpt.com/codex/tasks/task_e_68df936588d883339f0a92e8e61f8df6