### PR TITLE
Fix RL pipeline compilation issues

### DIFF
--- a/Clash SL Server/Clash SL Server.csproj
+++ b/Clash SL Server/Clash SL Server.csproj
@@ -276,6 +276,7 @@
       <DependentUpon>CSSdb.edmx</DependentUpon>
     </Compile>
     <Compile Include="Helpers\Binary\Reader.cs" />
+    <Compile Include="Helpers\BattleSerializers.cs" />
     <Compile Include="Helpers\List\Writter.cs" />
     <Compile Include="Logic\API\FacebookApi.cs" />
     <Compile Include="Logic\ClanWars.cs" />
@@ -283,6 +284,9 @@
     <Compile Include="Logic\Enums\Exits.cs" />
     <Compile Include="Logic\Enums\Save.cs" />
     <Compile Include="Logic\Enums\State.cs" />
+    <Compile Include="Logic\JSONProperty\Replay_Info.cs" />
+    <Compile Include="Logic\JSONProperty\Replay_Stats.cs" />
+    <Compile Include="Logic\JSONProperty\Item\Battle_Commands.cs" />
     <Compile Include="Logic\StreamEntry\ChallengeStreamEntry.cs" />
     <Compile Include="Packets\Commands\Client\CastSpellCommand.cs" />
     <Compile Include="Packets\Commands\Client\PlaceAllianceTroopsCommand.cs" />
@@ -416,8 +420,6 @@
     <Compile Include="Packets\Messages\Server\ReplayDataMessage.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Simulation\BatchAttackOptions.cs" />
-    <Compile Include="Simulation\BatchAttackRunner.cs" />
-    <Compile Include="Simulation\BatchAttackCore.cs" />
     <Compile Include="CSSUI.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1341,6 +1343,7 @@
     <Compile Include="Packets\Messages\Server\GlobalChatLineMessage.cs" />
     <Compile Include="Logic\StreamEntry\ChatStreamEntry.cs" />
     <Compile Include="Packets\Messages\Client\PromoteAllianceMemberMessage.cs" />
+    <Compile Include="Logic\Battle.cs" />
     <Compile Include="Logic\Alliance.cs" />
     <Compile Include="Core\ObjectManager.cs" />
     <Compile Include="Simulation\BatchAttackRunner.cs" />

--- a/Clash SL Server/Docs/minimal_attack_mode.md
+++ b/Clash SL Server/Docs/minimal_attack_mode.md
@@ -124,10 +124,11 @@ Key entry points:
   heavily weights stars, adds linear destruction credit, and slightly rewards
   faster clears. Implement `IRLBattlePolicy` yourself if you prefer advantage
   signals, curriculum shaping, etc.
-* **`RLBattlePipeline.Demo`** – accepts `(Battle battle, IEnumerable<Battle_Command>
-  seed)` tuples, primes the policy via `WarmStart`, and runs the episodes. It’s a
-  convenient entry point when you want to bootstrap from existing replay
-  commands without writing plumbing code.
+* **`RLBattlePipeline.Demo`** – accepts an `IEnumerable<RLEpisodeSeed>` (each seed
+  wraps a `Battle` plus optional `IEnumerable<Battle_Command>`), primes the
+  policy via `WarmStart`, and runs the episodes. It’s a convenient entry point
+  when you want to bootstrap from existing replay commands without writing
+  plumbing code.
 
 Because the pipeline resets command/replay state for every work item, you can
 reuse attacker/defender snapshots (or even memoized `Level` objects) when

--- a/Clash SL Server/Program.cs
+++ b/Clash SL Server/Program.cs
@@ -11,6 +11,7 @@ using CSS.Core.Threading;
 using CSS.Core.Web;
 using CSS.Helpers;
 using CSS.WebAPI;
+using UCS.Simulation;
 using static CSS.Core.Logger;
 
 namespace CSS
@@ -24,7 +25,7 @@ namespace CSS
 
         internal static void Main(string[] args)
         {
-            if (CSS.Simulation.BatchAttackRunner.TryRun(args))
+            if (BatchAttackRunner.TryRun(args))
             {
                 return;
             }

--- a/Clash SL Server/Simulation/BatchAttackCore.cs
+++ b/Clash SL Server/Simulation/BatchAttackCore.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using UCS.Helpers;
 using UCS.Logic;
 using UCS.Logic.JSONProperty;
 using UCS.Logic.JSONProperty.Item;
@@ -12,7 +13,10 @@ namespace UCS.Simulation
             IEnumerable<BatchAttackWorkItem> workItems,
             BatchAttackRunnerOptions options = null)
         {
-            options ??= BatchAttackRunnerOptions.Default;
+            if (options == null)
+            {
+                options = BatchAttackRunnerOptions.Default;
+            }
 
             var results = new List<BatchAttackResult>();
 
@@ -117,7 +121,10 @@ namespace UCS.Simulation
 
     internal class BatchAttackRunnerOptions
     {
-        internal static BatchAttackRunnerOptions Default => new BatchAttackRunnerOptions();
+        internal static BatchAttackRunnerOptions Default
+        {
+            get { return new BatchAttackRunnerOptions(); }
+        }
 
         internal bool ResetBattleCommands { get; set; } = true;
 

--- a/Clash SL Server/Simulation/BatchAttackOptions.cs
+++ b/Clash SL Server/Simulation/BatchAttackOptions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Globalization;
 using System.IO;
 
-namespace CSS.Simulation
+namespace UCS.Simulation
 {
     internal sealed class BatchAttackOptions
     {

--- a/Clash SL Server/Simulation/BatchAttackRunner.cs
+++ b/Clash SL Server/Simulation/BatchAttackRunner.cs
@@ -1,18 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using CSS.Core;
 using CSS.Logic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
-using System.Linq;
 using UCS.Helpers;
 using UCS.Logic;
 using UCS.Logic.JSONProperty;
 using UCS.Logic.JSONProperty.Item;
 
-namespace CSS.Simulation
+namespace UCS.Simulation
 {
     internal static class BatchAttackRunner
     {


### PR DESCRIPTION
## Summary
- align the simulation helpers under `UCS.Simulation`, drop tuple/pattern matching usage, and introduce `RLEpisodeSeed` for the demo helper
- add the missing project references for battle serialization and JSON models so `UCS.Logic` types resolve during compilation
- update the program entry point and docs to reflect the corrected namespaces and demo signature

## Testing
- not run (framework-specific project targeting .NET Framework)


------
https://chatgpt.com/codex/tasks/task_e_68e17d0c1b2c8333b8183f8a4f269863